### PR TITLE
Add operator earnings reentrancy test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -60,4 +60,8 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: High (access control)
   - *Test File*: `test/security/ssvdao-access-control.ts`
   - *Result*: Any address can invoke `updateMaximumOperatorFee` to alter `operatorMaxFee`.
-
+ 
+## Reentrancy on Operator Earnings Withdrawal
+- **Severity**: Medium
+- **Test File**: `test/security/operator-earnings-reentrancy.ts`
+- **Result**: No reentrancy observed; state updates precede token transfer, preventing double withdrawals.

--- a/test/security/operator-earnings-reentrancy.ts
+++ b/test/security/operator-earnings-reentrancy.ts
@@ -1,0 +1,61 @@
+import {
+  owners,
+  initializeContract,
+  registerOperators,
+  coldRegisterValidator,
+  bulkRegisterValidators,
+  CONFIG,
+  DEFAULT_OPERATOR_IDS,
+} from '../helpers/contract-helpers';
+import { expect } from 'chai';
+import { mine } from '@nomicfoundation/hardhat-network-helpers';
+
+let ssvNetwork: any, ssvViews: any, ssvToken: any;
+let networkFee: bigint, burnPerBlock: bigint, minDepositAmount: bigint;
+
+describe('Operator earnings reentrancy protections', () => {
+  beforeEach(async () => {
+    const metadata = await initializeContract('ReentrantToken');
+    ssvNetwork = metadata.ssvNetwork;
+    ssvViews = metadata.ssvNetworkViews;
+    ssvToken = metadata.ssvToken;
+
+    networkFee = CONFIG.minimalOperatorFee;
+    await registerOperators(0, 14, CONFIG.minimalOperatorFee);
+
+    burnPerBlock = CONFIG.minimalOperatorFee * 4n + networkFee;
+    minDepositAmount = BigInt(CONFIG.minimalBlocksBeforeLiquidation) * burnPerBlock;
+
+    await ssvNetwork.write.updateNetworkFee([networkFee]);
+
+    await coldRegisterValidator();
+
+    await bulkRegisterValidators(
+      4,
+      1,
+      DEFAULT_OPERATOR_IDS[4],
+      minDepositAmount,
+      { validatorCount: 0, networkFeeIndex: 0, index: 0, balance: 0n, active: true },
+    );
+
+    await mine(10);
+  });
+
+  it('withdrawAllOperatorEarnings not vulnerable to token reentrancy', async () => {
+    const operatorId = 1n;
+    await ssvToken.write.setReentrancyTarget([
+      ssvNetwork.address,
+      owners[0].account.address,
+      operatorId,
+    ]);
+
+    const earningsBefore = await ssvViews.read.getOperatorEarnings([operatorId]);
+    expect(earningsBefore).to.be.gt(0n);
+
+    await ssvNetwork.write.withdrawAllOperatorEarnings([operatorId]);
+
+    const earningsAfter = await ssvViews.read.getOperatorEarnings([operatorId]);
+    expect(earningsAfter).to.equal(0n);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add test verifying `withdrawAllOperatorEarnings` handles token reentrancy safely
- document operator earnings withdrawal reentrancy vector

## Testing
- `npx hardhat test test/security/operator-earnings-reentrancy.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab3e1cfa34832db9077eb6c85f1878