### PR TITLE
test: cover SSVDAO parameter access control

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -61,3 +61,23 @@ This document tracks security vectors analyzed in the repository.
   - *Test File*: `test/security/ssvdao-access-control.ts`
   - *Result*: Any address can invoke `updateMaximumOperatorFee` to alter `operatorMaxFee`.
 
+- **Unauthorized Declare Operator Fee Period Update**
+  - *Severity*: High (access control)
+  - *Test File*: `test/security/ssvdao-access-control.ts`
+  - *Result*: Any address can call `updateDeclareOperatorFeePeriod` to change `declareOperatorFeePeriod`.
+
+- **Unauthorized Execute Operator Fee Period Update**
+  - *Severity*: High (access control)
+  - *Test File*: `test/security/ssvdao-access-control.ts`
+  - *Result*: Any address can call `updateExecuteOperatorFeePeriod` to change `executeOperatorFeePeriod`.
+
+- **Unauthorized Liquidation Threshold Period Update**
+  - *Severity*: High (access control)
+  - *Test File*: `test/security/ssvdao-access-control.ts`
+  - *Result*: Any address can call `updateLiquidationThresholdPeriod` to change `minimumBlocksBeforeLiquidation`.
+
+- **Unauthorized Minimum Liquidation Collateral Update**
+  - *Severity*: High (access control)
+  - *Test File*: `test/security/ssvdao-access-control.ts`
+  - *Result*: Any address can call `updateMinimumLiquidationCollateral` to change `minimumLiquidationCollateral`.
+

--- a/test/security/ssvdao-access-control.ts
+++ b/test/security/ssvdao-access-control.ts
@@ -37,4 +37,44 @@ describe("SSVDAO module access control", function () {
       .withArgs(newLimit);
   });
 
+  it("allows any address to update declare operator fee period", async function () {
+    const [attacker] = await ethers.getSigners();
+    const Dao = await ethers.getContractFactory("SSVDAO");
+    const dao = await Dao.deploy();
+    const newPeriod = 1_000;
+    await expect(dao.connect(attacker).updateDeclareOperatorFeePeriod(newPeriod))
+      .to.emit(dao, "DeclareOperatorFeePeriodUpdated")
+      .withArgs(newPeriod);
+  });
+
+  it("allows any address to update execute operator fee period", async function () {
+    const [attacker] = await ethers.getSigners();
+    const Dao = await ethers.getContractFactory("SSVDAO");
+    const dao = await Dao.deploy();
+    const newPeriod = 1_000;
+    await expect(dao.connect(attacker).updateExecuteOperatorFeePeriod(newPeriod))
+      .to.emit(dao, "ExecuteOperatorFeePeriodUpdated")
+      .withArgs(newPeriod);
+  });
+
+  it("allows any address to update liquidation threshold period", async function () {
+    const [attacker] = await ethers.getSigners();
+    const Dao = await ethers.getContractFactory("SSVDAO");
+    const dao = await Dao.deploy();
+    const newThreshold = 100_800; // minimum allowed
+    await expect(dao.connect(attacker).updateLiquidationThresholdPeriod(newThreshold))
+      .to.emit(dao, "LiquidationThresholdPeriodUpdated")
+      .withArgs(newThreshold);
+  });
+
+  it("allows any address to update minimum liquidation collateral", async function () {
+    const [attacker] = await ethers.getSigners();
+    const Dao = await ethers.getContractFactory("SSVDAO");
+    const dao = await Dao.deploy();
+    const amount = ethers.parseEther("1");
+    await expect(dao.connect(attacker).updateMinimumLiquidationCollateral(amount))
+      .to.emit(dao, "MinimumLiquidationCollateralUpdated")
+      .withArgs(amount);
+  });
+
 });


### PR DESCRIPTION
## Summary
- add tests showing any address can adjust several SSVDAO protocol parameters
- document newly confirmed SSVDAO access-control issues in `TestedVectors.md`

## Testing
- `npx hardhat test test/security/ssvdao-access-control.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ab3e1cfa34832db9077eb6c85f1878