### PR TITLE
Add test for unauthorized SSVNetwork initialization

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -87,3 +87,8 @@ This document tracks security vectors analyzed in the repository.
   - *Test File*: `test/security/cluster-deposit-reentrancy.ts`
   - *Result*: Deposit resisted token-triggered reentrancy; operator earnings unchanged.
 
+
+- **Unauthorized Initialization of SSVNetwork**
+  - *Severity*: Critical (access control)
+  - *Test File*: `test/security/uninitialized-ownership.ts`
+  - *Result*: Uninitialized proxy can be claimed by any caller, who becomes owner and gains upgrade control.

--- a/test/security/uninitialized-ownership.ts
+++ b/test/security/uninitialized-ownership.ts
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+import { ethers, upgrades } from 'hardhat';
+
+describe('Security: Unauthorized initialization of SSVNetwork', function () {
+  it('allows arbitrary account to initialize and take ownership', async function () {
+    const [deployer, attacker] = await ethers.getSigners();
+
+    const SSVNetworkFactory = await ethers.getContractFactory('SSVNetwork');
+    const proxy = await upgrades.deployProxy(SSVNetworkFactory, [], {
+      kind: 'uups',
+      initializer: false,
+      unsafeAllow: ['delegatecall'],
+    });
+    await proxy.waitForDeployment();
+    const proxyAddress = await proxy.getAddress();
+
+    const ssvNetwork = await ethers.getContractAt('SSVNetwork', proxyAddress, attacker);
+    await ssvNetwork.initialize(
+      attacker.address,
+      attacker.address,
+      attacker.address,
+      attacker.address,
+      attacker.address,
+      0n,
+      0n,
+      0n,
+      0n,
+      0n,
+      0n,
+    );
+
+    expect(await ssvNetwork.owner()).to.equal(attacker.address);
+  });
+});


### PR DESCRIPTION
## Summary
- test SSVNetwork proxy initialization can be hijacked by any address
- document unauthorized initialization vector in TestedVectors

## Testing
- `npm test test/security/uninitialized-ownership.ts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab50844520832db038ce20f29c3063