### PR TITLE
Document operator fee increase limit vector

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -87,3 +87,7 @@ This document tracks security vectors analyzed in the repository.
   - *Test File*: `test/security/cluster-deposit-reentrancy.ts`
   - *Result*: Deposit resisted token-triggered reentrancy; operator earnings unchanged.
 
+- **Unauthorized Operator Fee Increase Limit Update**
+  - *Severity*: High (access control)
+  - *Test File*: `test/security/ssvdao-access-control.ts`
+  - *Result*: Any address can call `updateOperatorFeeIncreaseLimit` to alter `operatorMaxFeeIncrease`.


### PR DESCRIPTION
## Summary
- document lack of access control on SSVDAO.updateOperatorFeeIncreaseLimit

## Testing
- `npx hardhat test test/security/ssvdao-access-control.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab50844520832db038ce20f29c3063