### PR TITLE
test: add whitelisting contract access test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -87,3 +87,7 @@ This document tracks security vectors analyzed in the repository.
   - *Test File*: `test/security/cluster-deposit-reentrancy.ts`
   - *Result*: Deposit resisted token-triggered reentrancy; operator earnings unchanged.
 
+- **Unauthorized Operator Whitelisting Contract Update**
+  - *Severity*: Medium (access control)
+  - *Test File*: `test/security/operator-whitelisting-contract-access.ts`
+  - *Result*: Non-owners attempting to set a whitelisting contract revert with `CallerNotOwnerWithData`; owner succeeds.

--- a/test/security/operator-whitelisting-contract-access.ts
+++ b/test/security/operator-whitelisting-contract-access.ts
@@ -1,0 +1,36 @@
+import hre from 'hardhat';
+import { expect } from 'chai';
+import { initializeContract, owners, DataGenerator, CONFIG } from '../helpers/contract-helpers';
+
+describe('Security: operator whitelisting contract access control', () => {
+  let ssvNetwork: any;
+  let mockWhitelistingContract: any;
+
+  beforeEach(async () => {
+    const metadata = await initializeContract();
+    ssvNetwork = metadata.ssvNetwork;
+    mockWhitelistingContract = await hre.viem.deployContract('MockWhitelistingContract', [[]], {
+      client: owners[0].client,
+    });
+    await ssvNetwork.write.registerOperator([DataGenerator.publicKey(0), CONFIG.minimalOperatorFee, true], {
+      account: owners[1].account,
+    });
+  });
+
+  it('non-owner cannot set whitelisting contract', async () => {
+    await expect(
+      ssvNetwork.write.setOperatorsWhitelistingContract([[1], await mockWhitelistingContract.address], {
+        account: owners[2].account,
+      })
+    ).to.be.rejectedWith('CallerNotOwnerWithData');
+  });
+
+  it('operator owner can set whitelisting contract', async () => {
+    await expect(
+      ssvNetwork.write.setOperatorsWhitelistingContract([[1], await mockWhitelistingContract.address], {
+        account: owners[1].account,
+      })
+    ).to.not.be.rejected;
+  });
+});
+


### PR DESCRIPTION
## Summary
- add security test ensuring only operator owners can set whitelisting contract
- document operator whitelisting contract access control in TestedVectors

## Testing
- `npm test`
- `npx hardhat test test/security/operator-whitelisting-contract-access.ts`
- `npm run slither` *(fails: slither not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab508594b0832dae2aec0404e8bc22