### PR TITLE
doc: record operator fee increase limit vulnerability

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -87,3 +87,8 @@ This document tracks security vectors analyzed in the repository.
   - *Test File*: `test/security/cluster-deposit-reentrancy.ts`
   - *Result*: Deposit resisted token-triggered reentrancy; operator earnings unchanged.
 
+- **Unauthorized Operator Fee Increase Limit Update**
+  - *Severity*: High (access control)
+  - *Test File*: `test/security/ssvdao-access-control.ts`
+  - *Result*: Any address can call `updateOperatorFeeIncreaseLimit` to change `operatorMaxFeeIncrease`.
+


### PR DESCRIPTION
## Summary
- document missing access control for `SSVDAO.updateOperatorFeeIncreaseLimit` in TestedVectors

## Testing
- `npm test test/security/ssvdao-access-control.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ab508594b0832dae2aec0404e8bc22