### PR TITLE
test: cover views initialization and operator removal reentrancy

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -127,3 +127,12 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: High (access control)
   - *Test File*: `test/security/ssvdao-access-control.ts`
   - *Result*: Any address can call `updateOperatorFeeIncreaseLimit` to change `operatorMaxFeeIncrease`.
+**Unauthorized Initialization of SSVNetworkViews**
+  - *Severity*: Critical (access control)
+  - *Test File*: `test/security/uninitialized-views-ownership.ts`
+  - *Result*: Uninitialized proxy can be initialized by any address, granting ownership and upgrade rights.
+
+**Operator Removal Reentrancy**
+  - *Severity*: Medium (reentrancy)
+  - *Test File*: `test/security/remove-operator-reentrancy.ts`
+  - *Result*: No reentrancy observed; state updates occur before token transfer, preventing double withdrawals.

--- a/test/security/remove-operator-reentrancy.ts
+++ b/test/security/remove-operator-reentrancy.ts
@@ -1,0 +1,60 @@
+import {
+  owners,
+  initializeContract,
+  registerOperators,
+  coldRegisterValidator,
+  bulkRegisterValidators,
+  CONFIG,
+  DEFAULT_OPERATOR_IDS,
+} from '../helpers/contract-helpers';
+import { expect } from 'chai';
+import { mine } from '@nomicfoundation/hardhat-network-helpers';
+
+let ssvNetwork: any, ssvViews: any, ssvToken: any;
+let networkFee: bigint, burnPerBlock: bigint, minDepositAmount: bigint;
+
+describe('Operator removal reentrancy protections', () => {
+  beforeEach(async () => {
+    const metadata = await initializeContract('ReentrantToken');
+    ssvNetwork = metadata.ssvNetwork;
+    ssvViews = metadata.ssvNetworkViews;
+    ssvToken = metadata.ssvToken;
+
+    networkFee = CONFIG.minimalOperatorFee;
+    await registerOperators(0, 14, CONFIG.minimalOperatorFee);
+
+    burnPerBlock = CONFIG.minimalOperatorFee * 4n + networkFee;
+    minDepositAmount = BigInt(CONFIG.minimalBlocksBeforeLiquidation) * burnPerBlock;
+
+    await ssvNetwork.write.updateNetworkFee([networkFee]);
+
+    await coldRegisterValidator();
+
+    await bulkRegisterValidators(
+      4,
+      1,
+      DEFAULT_OPERATOR_IDS[4],
+      minDepositAmount,
+      { validatorCount: 0, networkFeeIndex: 0, index: 0, balance: 0n, active: true },
+    );
+
+    await mine(10);
+  });
+
+  it('removeOperator not vulnerable to token reentrancy', async () => {
+    const operatorId = 1n;
+    await ssvToken.write.setReentrancyTarget([
+      ssvNetwork.address,
+      owners[0].account.address,
+      operatorId,
+    ]);
+
+    const earningsBefore = await ssvViews.read.getOperatorEarnings([operatorId]);
+    expect(earningsBefore).to.be.gt(0n);
+
+    await ssvNetwork.write.removeOperator([operatorId], { account: owners[0].account });
+
+    const earningsAfter = await ssvViews.read.getOperatorEarnings([operatorId]);
+    expect(earningsAfter).to.equal(0n);
+  });
+});

--- a/test/security/uninitialized-views-ownership.ts
+++ b/test/security/uninitialized-views-ownership.ts
@@ -1,0 +1,22 @@
+import { expect } from 'chai';
+import { ethers, upgrades } from 'hardhat';
+
+describe('Security: Unauthorized initialization of SSVNetworkViews', function () {
+  it('allows arbitrary account to initialize and take ownership', async function () {
+    const [deployer, attacker] = await ethers.getSigners();
+
+    const ViewsFactory = await ethers.getContractFactory('SSVNetworkViews');
+    const proxy = await upgrades.deployProxy(ViewsFactory, [], {
+      kind: 'uups',
+      initializer: false,
+      unsafeAllow: ['delegatecall'],
+    });
+    await proxy.waitForDeployment();
+    const proxyAddress = await proxy.getAddress();
+
+    const views = await ethers.getContractAt('SSVNetworkViews', proxyAddress, attacker);
+    await views.initialize(attacker.address);
+
+    expect(await views.owner()).to.equal(attacker.address);
+  });
+});


### PR DESCRIPTION
## Summary
- add security test showing SSVNetworkViews can be initialized by any account
- add test ensuring removeOperator resists token-triggered reentrancy
- document tested vectors in TestedVectors.md

## Testing
- `npx hardhat test test/security/uninitialized-views-ownership.ts`
- `npx hardhat test test/security/remove-operator-reentrancy.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab7ebe6104832da974e89b8a9ee300