### PR TITLE
Add test for unauthorized initialization of SSVNetworkViews

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -127,3 +127,7 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: High (access control)
   - *Test File*: `test/security/ssvdao-access-control.ts`
   - *Result*: Any address can call `updateOperatorFeeIncreaseLimit` to change `operatorMaxFeeIncrease`.
+- **Unauthorized Initialization of SSVNetworkViews**
+  - *Severity*: Medium (access control)
+  - *Test File*: `test/security/uninitialized-views.ts`
+  - *Result*: Uninitialized proxy can be initialized by any account, granting ownership.

--- a/test/security/uninitialized-views.ts
+++ b/test/security/uninitialized-views.ts
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import { ethers, upgrades } from 'hardhat';
+
+describe('Security: Unauthorized initialization of SSVNetworkViews', function () {
+  it('allows arbitrary account to initialize and take ownership', async function () {
+    const [deployer, attacker] = await ethers.getSigners();
+
+    const ViewsFactory = await ethers.getContractFactory('SSVNetworkViews');
+    const proxy = await upgrades.deployProxy(ViewsFactory, [], {
+      kind: 'uups',
+      initializer: false,
+    });
+    await proxy.waitForDeployment();
+    const proxyAddress = await proxy.getAddress();
+
+    const views = await ethers.getContractAt('SSVNetworkViews', proxyAddress, attacker);
+    await views.initialize(attacker.address);
+
+    expect(await views.owner()).to.equal(attacker.address);
+  });
+});


### PR DESCRIPTION
## Summary
- test that uninitialized SSVNetworkViews proxy can be claimed by any account
- record the attack vector in TestedVectors documentation

## Testing
- `npm test test/security/uninitialized-views.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab7ebe6104832da974e89b8a9ee300