### PR TITLE
Document operator removal access control in TestedVectors

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -127,3 +127,7 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: High (access control)
   - *Test File*: `test/security/ssvdao-access-control.ts`
   - *Result*: Any address can call `updateOperatorFeeIncreaseLimit` to change `operatorMaxFeeIncrease`.
+- **Unauthorized Operator Removal**
+  - *Severity*: Medium (access control)
+  - *Test File*: `test/operators/remove.ts`
+  - *Result*: Non-owner attempts revert with `CallerNotOwnerWithData`; vector managed.


### PR DESCRIPTION
## Summary
- record unauthorized operator removal access control test results

## Testing
- `npx hardhat test test/operators/remove.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ab7ec0fdc0832dadb40c550cc5e81c