### PR TITLE
Add test for validatorsPerOperator reinitializer access control

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -127,3 +127,7 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: High (access control)
   - *Test File*: `test/security/ssvdao-access-control.ts`
   - *Result*: Any address can call `updateOperatorFeeIncreaseLimit` to change `operatorMaxFeeIncrease`.
+**Unauthorized validators-per-operator limit update via reinitializer**
+  - *Severity*: High (access control)
+  - *Test File*: `test/security/validators-per-operator-initialize.ts`
+  - *Result*: Any address can call `initializev2` to change `validatorsPerOperatorLimit`.

--- a/test/security/validators-per-operator-initialize.ts
+++ b/test/security/validators-per-operator-initialize.ts
@@ -1,0 +1,28 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import hre from "hardhat";
+import { initializeContract } from "../helpers/contract-helpers";
+
+describe("SSVNetwork validatorsPerOperatorLimit reinitializer", function () {
+  it("allows any address to invoke initializev2", async function () {
+    const { ssvContractsOwner, ssvNetwork, ssvNetworkViews } = await initializeContract();
+    const [, attacker] = await hre.viem.getWalletClients();
+
+    const Upgrade = await ethers.getContractFactory("SSVNetworkValidatorsPerOperatorUpgrade");
+    const upgradeImpl = await Upgrade.deploy();
+    await upgradeImpl.waitForDeployment();
+    const implAddress = await upgradeImpl.getAddress();
+
+    await ssvNetwork.write.upgradeTo([implAddress], { account: ssvContractsOwner });
+
+    const upgraded = await hre.viem.getContractAt(
+      "SSVNetworkValidatorsPerOperatorUpgrade",
+      ssvNetwork.address as `0x${string}`
+    );
+
+    const newLimit = 123n;
+    await upgraded.write.initializev2([newLimit], { account: attacker.account });
+
+    expect(await ssvNetworkViews.read.getValidatorsPerOperatorLimit()).to.equal(newLimit);
+  });
+});


### PR DESCRIPTION
## Summary
- add security test showing `initializev2` reinitializer can be called by any address
- document the validators-per-operator limit access control issue

## Testing
- `npm test test/security/validators-per-operator-initialize.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ab7ec0fdc0832dadb40c550cc5e81c