### PR TITLE
test: cover unauthorized upgrade initializers

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -127,3 +127,12 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: High (access control)
   - *Test File*: `test/security/ssvdao-access-control.ts`
   - *Result*: Any address can call `updateOperatorFeeIncreaseLimit` to change `operatorMaxFeeIncrease`.
+- **Unauthorized SSVNetworkViews Initialization**
+  - *Severity*: Medium (access control)
+  - *Test File*: `test/security/uninitialized-views-ownership.ts`
+  - *Result*: Any address can initialize the SSVNetworkViews proxy and become owner.
+
+- **Unauthorized initializev2 Execution After Upgrade**
+  - *Severity*: High (access control)
+  - *Test File*: `test/security/upgrade-initializev2.ts`
+  - *Result*: After upgrading, any address can call `initializev2` to change `validatorsPerOperatorLimit`.

--- a/test/security/uninitialized-views-ownership.ts
+++ b/test/security/uninitialized-views-ownership.ts
@@ -1,0 +1,22 @@
+import { expect } from 'chai';
+import { ethers, upgrades } from 'hardhat';
+
+describe('Security: Unauthorized initialization of SSVNetworkViews', function () {
+  it('allows arbitrary account to initialize and take ownership', async function () {
+    const [deployer, attacker] = await ethers.getSigners();
+
+    const ViewsFactory = await ethers.getContractFactory('SSVNetworkViews');
+    const proxy = await upgrades.deployProxy(ViewsFactory, [], {
+      kind: 'uups',
+      initializer: false,
+      unsafeAllow: ['delegatecall'],
+    });
+    await proxy.waitForDeployment();
+    const proxyAddress = await proxy.getAddress();
+
+    const views = await ethers.getContractAt('SSVNetworkViews', proxyAddress, attacker);
+    await views.initialize(attacker.address);
+
+    expect(await views.owner()).to.equal(attacker.address);
+  });
+});

--- a/test/security/upgrade-initializev2.ts
+++ b/test/security/upgrade-initializev2.ts
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import hre from 'hardhat';
+import { Address } from 'viem';
+import { initializeContract, owners } from '../helpers/contract-helpers';
+
+describe('Security: Unauthorized initializev2 after upgrade', () => {
+  it('allows non-owner to call initializev2', async () => {
+    const { ssvNetwork, ssvNetworkViews } = await initializeContract();
+
+    const deployedSSVNetwork = await hre.viem.getContractAt('SSVNetwork', ssvNetwork.address as Address);
+
+    const upgradeImpl = await hre.viem.deployContract(
+      'contracts/test/SSVNetworkValidatorsPerOperator.sol:SSVNetworkValidatorsPerOperatorUpgrade',
+      [],
+    );
+
+    await deployedSSVNetwork.write.upgradeTo([upgradeImpl.address]);
+
+    const upgraded = await hre.viem.getContractAt(
+      'contracts/test/SSVNetworkValidatorsPerOperator.sol:SSVNetworkValidatorsPerOperatorUpgrade',
+      ssvNetwork.address as Address,
+    );
+
+    await upgraded.write.initializev2([999], { account: owners[1].account });
+
+    expect(await ssvNetworkViews.read.getValidatorsPerOperatorLimit()).to.equal(999);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for unprotected SSVNetworkViews initializer
- add tests for unrestricted `initializev2` after upgrading
- document new attack vectors

## Testing
- `npx hardhat test test/security/uninitialized-views-ownership.ts test/security/upgrade-initializev2.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab7ec0fdc0832dadb40c550cc5e81c