### PR TITLE
Add SSVNetworkViews initialization takeover test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -127,3 +127,7 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: High (access control)
   - *Test File*: `test/security/ssvdao-access-control.ts`
   - *Result*: Any address can call `updateOperatorFeeIncreaseLimit` to change `operatorMaxFeeIncrease`.
+- **Unauthorized Initialization of SSVNetworkViews**
+  - *Severity*: Medium (access control)
+  - *Test File*: `test/security/uninitialized-views-ownership.ts`
+  - *Result*: Uninitialized `SSVNetworkViews` proxy can be initialized by any caller, granting ownership.

--- a/test/security/uninitialized-views-ownership.ts
+++ b/test/security/uninitialized-views-ownership.ts
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+import { ethers, upgrades } from 'hardhat';
+
+describe('Security: Unauthorized initialization of SSVNetworkViews', function () {
+  it('allows arbitrary account to initialize and take ownership', async function () {
+    const [deployer, attacker] = await ethers.getSigners();
+
+    const ViewsFactory = await ethers.getContractFactory('SSVNetworkViews');
+    const proxy = await upgrades.deployProxy(ViewsFactory, [], {
+      kind: 'uups',
+      initializer: false,
+    });
+    const proxyAddress = await proxy.getAddress();
+
+    const views = await ethers.getContractAt('SSVNetworkViews', proxyAddress, attacker);
+    await views.initialize(attacker.address);
+
+    expect(await views.owner()).to.equal(attacker.address);
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test demonstrating uninitialized `SSVNetworkViews` proxy can be claimed by arbitrary account
- document the new attack vector in `TestedVectors.md`

## Testing
- `npm test -- test/security/uninitialized-views-ownership.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ab7ec0fdc0832dadb40c550cc5e81c