### PR TITLE
test: add liquidation reentrancy check

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -166,3 +166,7 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: High (access control)
   - *Test File*: `test/security/upgrade-initializev2.ts`
   - *Result*: After upgrading, any address can call `initializev2` to change `validatorsPerOperatorLimit`.
+**Cluster Liquidation Reentrancy**
+  - *Severity*: Medium (reentrancy)
+  - *Test File*: `test/security/liquidate-reentrancy.ts`
+  - *Result*: No reentrancy observed; liquidation transfers funds once and updates state before token transfer.

--- a/contracts/test/mocks/ReentrantTokenGeneric.sol
+++ b/contracts/test/mocks/ReentrantTokenGeneric.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @notice ERC20 token to test generic reentrancy scenarios
+contract ReentrantTokenGeneric is ERC20, Ownable {
+    address public target;
+    address public trigger;
+    bytes public data;
+    bool internal reentered;
+
+    constructor() ERC20("Reentrant Token Generic", "RTG") {
+        _mint(msg.sender, 1000000000000000000000);
+    }
+
+    function mint(address to, uint256 amount) external onlyOwner {
+        _mint(to, amount);
+    }
+
+    function setReentrancyTarget(address _target, address _trigger, bytes calldata _data) external {
+        target = _target;
+        trigger = _trigger;
+        data = _data;
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal override {
+        super._transfer(from, to, amount);
+        if (!reentered && to == trigger && target != address(0)) {
+            reentered = true;
+            target.call(data);
+        }
+    }
+}
+

--- a/test/security/liquidate-reentrancy.ts
+++ b/test/security/liquidate-reentrancy.ts
@@ -1,0 +1,78 @@
+import {
+  owners,
+  initializeContract,
+  registerOperators,
+  coldRegisterValidator,
+  bulkRegisterValidators,
+  CONFIG,
+  DEFAULT_OPERATOR_IDS,
+} from '../helpers/contract-helpers';
+import { expect } from 'chai';
+import { mine } from '@nomicfoundation/hardhat-network-helpers';
+import { encodeFunctionData } from 'viem';
+
+let ssvNetwork: any, ssvViews: any, ssvToken: any;
+let minDepositAmount: bigint;
+let cluster: any;
+let networkFee: bigint;
+
+describe('Cluster liquidation reentrancy', () => {
+  beforeEach(async () => {
+    const metadata = await initializeContract('ReentrantTokenGeneric');
+    ssvNetwork = metadata.ssvNetwork;
+    ssvViews = metadata.ssvNetworkViews;
+    ssvToken = metadata.ssvToken;
+
+    await registerOperators(0, 14, CONFIG.minimalOperatorFee);
+
+    networkFee = CONFIG.minimalOperatorFee;
+    await ssvNetwork.write.updateNetworkFee([networkFee]);
+
+    minDepositAmount = BigInt(CONFIG.minimalBlocksBeforeLiquidation) * (networkFee + CONFIG.minimalOperatorFee * 4n);
+
+    await coldRegisterValidator();
+
+    cluster = (
+      await bulkRegisterValidators(
+        4,
+        1,
+        DEFAULT_OPERATOR_IDS[4],
+        minDepositAmount,
+        { validatorCount: 0, networkFeeIndex: 0, index: 0, balance: 0n, active: true },
+      )
+    ).args;
+
+    await mine(10);
+  });
+
+  it('liquidate not vulnerable to token reentrancy', async () => {
+    const callData = encodeFunctionData({
+      abi: ssvNetwork.abi,
+      functionName: 'liquidate',
+      args: [cluster.owner, cluster.operatorIds, cluster.cluster],
+    });
+
+    await ssvToken.write.setReentrancyTarget([
+      ssvNetwork.address,
+      cluster.owner,
+      callData,
+    ]);
+
+    const balanceBefore = await ssvToken.read.balanceOf([cluster.owner]);
+    const claimable = await ssvViews.read.getBalance([
+      cluster.owner,
+      cluster.operatorIds,
+      cluster.cluster,
+    ]);
+
+    await ssvNetwork.write.liquidate(
+      [cluster.owner, cluster.operatorIds, cluster.cluster],
+      { account: owners[4].account },
+    );
+
+    const balanceAfter = await ssvToken.read.balanceOf([cluster.owner]);
+    const perBlockBurn = networkFee + CONFIG.minimalOperatorFee * 4n;
+    expect(balanceAfter - balanceBefore).to.equal(claimable - perBlockBurn);
+  });
+});
+


### PR DESCRIPTION
## Summary
- test reentrancy protections on cluster liquidation
- add generic reentrant token mock
- document liquidation reentrancy vector

## Testing
- `npx hardhat test test/security/liquidate-reentrancy.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ace77a92e0832db63907be5bc098c2