### PR TITLE
test: ensure deposit reverts on failing ERC20

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -166,3 +166,7 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: High (access control)
   - *Test File*: `test/security/upgrade-initializev2.ts`
   - *Result*: After upgrading, any address can call `initializev2` to change `validatorsPerOperatorLimit`.
+**Non-Compliant ERC20 Deposit**
+- *Severity*: Medium (token handling)
+- *Test File*: `test/security/non-compliant-token.ts`
+- *Result*: Deposit attempts with tokens returning false revert with `TokenTransferFailed`, preventing inconsistent state.

--- a/contracts/test/mocks/FailingToken.sol
+++ b/contracts/test/mocks/FailingToken.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @notice ERC20 token that always fails transfers, used for testing
+contract FailingToken is ERC20 {
+    constructor() ERC20("Failing Token", "FAIL") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function transfer(address to, uint256 amount) public override returns (bool) {
+        to; amount; // suppress warnings
+        return false;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
+        from; to; amount; // suppress warnings
+        return false;
+    }
+}

--- a/test/security/non-compliant-token.ts
+++ b/test/security/non-compliant-token.ts
@@ -1,0 +1,16 @@
+import { initializeContract, registerOperators, coldRegisterValidator, CONFIG } from '../helpers/contract-helpers';
+import { expect } from 'chai';
+
+let ssvNetwork: any;
+
+describe('Non-compliant ERC20 token handling', () => {
+  beforeEach(async () => {
+    const metadata = await initializeContract('FailingToken');
+    ssvNetwork = metadata.ssvNetwork;
+    await registerOperators(0, 4, CONFIG.minimalOperatorFee);
+  });
+
+  it('reverts when token transfer returns false', async () => {
+    await expect(coldRegisterValidator()).to.be.rejectedWith('TokenTransferFailed');
+  });
+});


### PR DESCRIPTION
## Summary
- add FailingToken mock that always returns false on transfers
- test registering validator reverts with TokenTransferFailed when token transfer fails
- document token failure vector in TestedVectors

## Testing
- `npm test test/security/non-compliant-token.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ace77a92e0832db63907be5bc098c2