### PR TITLE
Add operator zero-withdrawal test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -166,3 +166,7 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: High (access control)
   - *Test File*: `test/security/upgrade-initializev2.ts`
   - *Result*: After upgrading, any address can call `initializev2` to change `validatorsPerOperatorLimit`.
+**Zero-Amount Operator Earnings Withdrawal**
+ - *Severity*: Medium (accounting manipulation)
+ - *Test File*: `test/security/operator-zero-withdraw.ts`
+ - *Result*: Calling `withdrawOperatorEarnings(0)` by the operator owner withdraws all earnings, while non-owners revert with `CallerNotOwnerWithData`; vector managed.

--- a/test/security/operator-zero-withdraw.ts
+++ b/test/security/operator-zero-withdraw.ts
@@ -1,0 +1,59 @@
+import { expect } from 'chai';
+import { mine } from '@nomicfoundation/hardhat-network-helpers';
+import {
+  owners,
+  initializeContract,
+  registerOperators,
+  coldRegisterValidator,
+  bulkRegisterValidators,
+  CONFIG,
+  DEFAULT_OPERATOR_IDS,
+} from '../helpers/contract-helpers';
+
+describe('Operator zero amount earnings withdrawal', () => {
+  let ssvNetwork: any;
+  let ssvViews: any;
+
+  beforeEach(async () => {
+    const metadata = await initializeContract();
+    ssvNetwork = metadata.ssvNetwork;
+    ssvViews = metadata.ssvNetworkViews;
+
+    await registerOperators(0, 4, CONFIG.minimalOperatorFee);
+
+    const burnPerBlock = CONFIG.minimalOperatorFee * 4n;
+    const minDepositAmount = BigInt(CONFIG.minimalBlocksBeforeLiquidation) * burnPerBlock;
+
+    await coldRegisterValidator();
+    await bulkRegisterValidators(
+      4,
+      1,
+      DEFAULT_OPERATOR_IDS[4],
+      minDepositAmount,
+      { validatorCount: 0, networkFeeIndex: 0, index: 0, balance: 0n, active: true },
+    );
+
+    await mine(10);
+  });
+
+  it('withdrawOperatorEarnings with amount 0 withdraws all earnings for owner', async () => {
+    const operatorId = 1n;
+    const earningsBefore = await ssvViews.read.getOperatorEarnings([operatorId]);
+    expect(earningsBefore).to.be.gt(0n);
+
+    await ssvNetwork.write.withdrawOperatorEarnings([operatorId, 0n], {
+      account: owners[0].account,
+    });
+    const earningsAfter = await ssvViews.read.getOperatorEarnings([operatorId]);
+    expect(earningsAfter).to.equal(0n);
+  });
+
+  it('non-owner cannot withdraw operator earnings', async () => {
+    const operatorId = 1n;
+    await expect(
+      ssvNetwork.write.withdrawOperatorEarnings([operatorId, 0n], {
+        account: owners[1].account,
+      }),
+    ).to.be.rejectedWith('CallerNotOwnerWithData');
+  });
+});


### PR DESCRIPTION
## Summary
- test operator earnings withdrawals with zero amount to ensure accounting safety and owner restriction
- document zero-amount operator earnings withdrawal vector

## Testing
- `npm test test/security/operator-zero-withdraw.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ace77a92e0832db63907be5bc098c2