### PR TITLE
Add zero address whitelist security test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -166,3 +166,8 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: High (access control)
   - *Test File*: `test/security/upgrade-initializev2.ts`
   - *Result*: After upgrading, any address can call `initializev2` to change `validatorsPerOperatorLimit`.
+**Zero Address Operator Whitelisting**
+ - *Severity*: Medium (input validation)
+ - *Test File*: `test/security/zero-address-whitelist.ts`
+ - *Result*: Attempting to whitelist address(0) reverts with `ZeroAddressNotAllowed`, indicating the vector is managed.
+

--- a/test/security/zero-address-whitelist.ts
+++ b/test/security/zero-address-whitelist.ts
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { initializeContract, registerOperators, owners, CONFIG } from '../helpers/contract-helpers';
+
+describe('Security: zero address operator whitelist', () => {
+  let ssvNetwork: any;
+
+  beforeEach(async () => {
+    const metadata = await initializeContract();
+    ssvNetwork = metadata.ssvNetwork;
+    await registerOperators(0, 1, CONFIG.minimalOperatorFee);
+  });
+
+  it('reverts when zero address is whitelisted', async () => {
+    await expect(
+      ssvNetwork.write.setOperatorsWhitelists([[1], [ethers.ZeroAddress]], {
+        account: owners[0].account,
+      }),
+    ).to.be.rejectedWith('ZeroAddressNotAllowed');
+  });
+});


### PR DESCRIPTION
## Summary
- add test confirming zero address cannot be added to operator whitelist
- document zero address whitelist protection in TestedVectors

## Testing
- `npx hardhat test --parallel test/security/zero-address-whitelist.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ace77cf77c832da2810c7d22edcd58