### PR TITLE
test: capture delegatecall empty revert

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -166,3 +166,7 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: High (access control)
   - *Test File*: `test/security/upgrade-initializev2.ts`
   - *Result*: After upgrading, any address can call `initializev2` to change `validatorsPerOperatorLimit`.
+**Silent delegatecall failure on empty revert data**
+  - *Severity*: High (error handling)
+  - *Test File*: `test/security/delegatecall-empty-revert.ts`
+  - *Result*: Delegatecall to module reverting with no data does not bubble the revert, allowing execution to proceed.

--- a/contracts/test/DelegateCallHarness.sol
+++ b/contracts/test/DelegateCallHarness.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.24;
+
+contract EmptyReverter {
+    fallback() external payable {
+        revert();
+    }
+}
+
+contract DelegateCallHarness {
+    function callDelegate(address target) external returns (bytes memory) {
+        (bool success, bytes memory result) = target.delegatecall("");
+        if (!success && result.length > 0) {
+            assembly {
+                let returndata_size := mload(result)
+                revert(add(32, result), returndata_size)
+            }
+        }
+        return result;
+    }
+}

--- a/test/security/delegatecall-empty-revert.ts
+++ b/test/security/delegatecall-empty-revert.ts
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+
+describe('Delegatecall empty revert handling', function () {
+  it('does not bubble up revert with empty data', async function () {
+    const Reverter = await ethers.getContractFactory('EmptyReverter');
+    const reverter = await Reverter.deploy();
+    const Harness = await ethers.getContractFactory('DelegateCallHarness');
+    const harness = await Harness.deploy();
+
+    await expect(harness.callDelegate(reverter.getAddress())).to.not.be.reverted;
+  });
+});


### PR DESCRIPTION
## Summary
- add harness and test demonstrating delegatecall ignoring empty revert data
- document delegatecall empty revert vector

## Testing
- `npx hardhat test test/security/delegatecall-empty-revert.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ace77cf77c832da2810c7d22edcd58