### PR TITLE
test: expose DAO earnings overflow

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -166,3 +166,7 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: High (access control)
   - *Test File*: `test/security/upgrade-initializev2.ts`
   - *Result*: After upgrading, any address can call `initializev2` to change `validatorsPerOperatorLimit`.
+**Network Earnings Overflow via Excessive Network Fee**
+  - *Severity*: High (arithmetic overflow)
+  - *Test File*: `test/security/ssvdao-overflow.ts`
+  - *Result*: With >1 validator, setting `networkFee` to `2^64-1` causes `withdrawNetworkEarnings` to revert with panic 0x11 due to overflow, halting earnings withdrawals.

--- a/test/security/ssvdao-overflow.ts
+++ b/test/security/ssvdao-overflow.ts
@@ -1,0 +1,37 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+
+// This test demonstrates that setting an excessively large network fee in the
+// SSVDAO module can cause arithmetic overflow in network earnings calculation.
+describe("SSVDAO network earnings overflow", function () {
+  it("reverts due to overflow when earnings exceed uint64", async function () {
+    const [attacker] = await ethers.getSigners();
+    const Dao = await ethers.getContractFactory("SSVDAO");
+    const dao = await Dao.deploy();
+    await dao.waitForDeployment();
+
+    // Manually set daoValidatorCount to 2 in storage to simulate existing validators
+    const baseSlot = BigInt(
+      ethers.keccak256(ethers.toUtf8Bytes("ssv.network.storage.protocol"))
+    ) - 1n;
+    const slotHex = ethers.toBeHex(baseSlot, 32);
+    const value =
+      "0x" + (2n << 32n).toString(16).padStart(64, "0");
+    await ethers.provider.send("hardhat_setStorageAt", [
+      await dao.getAddress(),
+      slotHex,
+      value,
+    ]);
+
+    // Set the network fee to the maximum allowed value
+    const maxFee = ((1n << 64n) - 1n) * 10000000n;
+    await dao.connect(attacker).updateNetworkFee(maxFee);
+
+    // Advance one block so network earnings calculation uses non-zero block diff
+    await ethers.provider.send("evm_mine", []);
+
+    await expect(
+      dao.connect(attacker).withdrawNetworkEarnings(0)
+    ).to.be.revertedWithPanic(0x11); // arithmetic overflow
+  });
+});


### PR DESCRIPTION
## Summary
- document and test arithmetic overflow in SSVDAO network earnings calculation

## Testing
- `npm test test/security/ssvdao-overflow.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ace77cf77c832da2810c7d22edcd58