### PR TITLE
Add whitelist removal access-control test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -166,3 +166,8 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: High (access control)
   - *Test File*: `test/security/upgrade-initializev2.ts`
   - *Result*: After upgrading, any address can call `initializev2` to change `validatorsPerOperatorLimit`.
+
+**Unauthorized Whitelisting Contract Removal**
+  - *Severity*: Medium (access control)
+  - *Test File*: `test/security/operator-whitelisting-contract-access.ts`
+  - *Result*: Non-owner attempts to remove operator whitelisting contract revert with `CallerNotOwnerWithData`; vector managed.

--- a/test/security/operator-whitelisting-contract-access.ts
+++ b/test/security/operator-whitelisting-contract-access.ts
@@ -32,5 +32,23 @@ describe('Security: operator whitelisting contract access control', () => {
       })
     ).to.not.be.rejected;
   });
+
+  it('non-owner cannot remove whitelisting contract', async () => {
+    await ssvNetwork.write.setOperatorsWhitelistingContract([[1], await mockWhitelistingContract.address], {
+      account: owners[1].account,
+    });
+    await expect(
+      ssvNetwork.write.removeOperatorsWhitelistingContract([[1]], { account: owners[2].account })
+    ).to.be.rejectedWith('CallerNotOwnerWithData');
+  });
+
+  it('operator owner can remove whitelisting contract', async () => {
+    await ssvNetwork.write.setOperatorsWhitelistingContract([[1], await mockWhitelistingContract.address], {
+      account: owners[1].account,
+    });
+    await expect(
+      ssvNetwork.write.removeOperatorsWhitelistingContract([[1]], { account: owners[1].account })
+    ).to.not.be.rejected;
+  });
 });
 


### PR DESCRIPTION
## Summary
- add tests covering unauthorized removal of operator whitelisting contracts
- document whitelist removal access-control vector

## Testing
- `npm test test/security/operator-whitelisting-contract-access.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ace77cf77c832da2810c7d22edcd58