### PR TITLE
Add test for unsorted whitelist IDs

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -200,3 +200,8 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: Medium (access control)
   - *Test File*: `test/security/operator-whitelisting-contract-access.ts`
   - *Result*: Non-owner attempts to remove operator whitelisting contract revert with `CallerNotOwnerWithData`; vector managed.
+**Unsorted Operator IDs in Whitelist Update**
+  - *Severity*: Medium (input validation)
+  - *Test File*: `test/security/unsorted-whitelist.ts`
+  - *Result*: `setOperatorsWhitelists` reverts with "UnsortedOperatorsList" when operator IDs are not sorted; vector managed.
+

--- a/test/security/unsorted-whitelist.ts
+++ b/test/security/unsorted-whitelist.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import { initializeContract, owners, CONFIG, registerOperators, ssvNetwork } from '../helpers/contract-helpers';
+
+describe('Security: unsorted operator IDs in whitelist update', () => {
+  beforeEach(async () => {
+    await initializeContract();
+    await registerOperators(1, 5, CONFIG.minimalOperatorFee);
+  });
+
+  it('setOperatorsWhitelists with unsorted operator IDs reverts', async () => {
+    const unsortedOperatorIds = [1, 3, 2, 4, 5];
+    const whitelistAddresses = owners.slice(0, 5).map(owner => owner.account.address);
+    await expect(
+      ssvNetwork.write.setOperatorsWhitelists([unsortedOperatorIds, whitelistAddresses], {
+        account: owners[1].account,
+      })
+    ).to.be.rejectedWith('UnsortedOperatorsList');
+  });
+});


### PR DESCRIPTION
## Summary
- add security test ensuring unsorted operator IDs in whitelist updates revert
- document input validation for unsorted operator IDs in TestedVectors

## Testing
- `npx hardhat test test/security/unsorted-whitelist.ts`

------
https://chatgpt.com/codex/tasks/task_e_68adf0ae5354832db32d8fefba5696de