### PR TITLE
Add validator registration reentrancy test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -200,3 +200,7 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: Medium (access control)
   - *Test File*: `test/security/operator-whitelisting-contract-access.ts`
   - *Result*: Non-owner attempts to remove operator whitelisting contract revert with `CallerNotOwnerWithData`; vector managed.
+**Validator Registration Reentrancy**
+ - *Severity*: Medium (reentrancy)
+ - *Test File*: `test/security/register-validator-reentrancy.ts`
+ - *Result*: Token-triggered reentrancy during `registerValidator` does not reduce operator earnings; state changes occur safely before token transfer.

--- a/test/security/register-validator-reentrancy.ts
+++ b/test/security/register-validator-reentrancy.ts
@@ -1,0 +1,37 @@
+import {
+  initializeContract,
+  registerOperators,
+  coldRegisterValidator,
+  CONFIG,
+} from '../helpers/contract-helpers';
+import { expect } from 'chai';
+
+let ssvNetwork: any, ssvViews: any, ssvToken: any;
+
+describe('Register validator reentrancy protections', () => {
+  beforeEach(async () => {
+    const metadata = await initializeContract('ReentrantToken');
+    ssvNetwork = metadata.ssvNetwork;
+    ssvViews = metadata.ssvNetworkViews;
+    ssvToken = metadata.ssvToken;
+
+    await registerOperators(0, 4, CONFIG.minimalOperatorFee);
+    await ssvNetwork.write.updateNetworkFee([CONFIG.minimalOperatorFee]);
+  });
+
+  it('registerValidator not vulnerable to token reentrancy', async () => {
+    const operatorId = 1n;
+    await ssvToken.write.setReentrancyTarget([
+      ssvNetwork.address,
+      ssvNetwork.address,
+      operatorId,
+    ]);
+
+    const earningsBefore = await ssvViews.read.getOperatorEarnings([operatorId]);
+
+    await coldRegisterValidator();
+
+    const earningsAfter = await ssvViews.read.getOperatorEarnings([operatorId]);
+    expect(earningsAfter).to.be.gte(earningsBefore);
+  });
+});


### PR DESCRIPTION
## Summary
- test `registerValidator` behavior against token-triggered reentrancy
- document validator registration reentrancy vector

## Testing
- `npx hardhat test test/security/register-validator-reentrancy.ts`


------
https://chatgpt.com/codex/tasks/task_e_68adf0ae5354832db32d8fefba5696de