### PR TITLE
Add operator fee reduction access control test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -200,3 +200,7 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: Medium (access control)
   - *Test File*: `test/security/operator-whitelisting-contract-access.ts`
   - *Result*: Non-owner attempts to remove operator whitelisting contract revert with `CallerNotOwnerWithData`; vector managed.
+**Unauthorized Operator Fee Reduction**
+  - *Severity*: Medium (access control)
+  - *Test File*: `test/security/operator-reduce-fee-access.ts`
+  - *Result*: Non-owner calls revert with `CallerNotOwnerWithData`; vector managed.

--- a/test/security/operator-reduce-fee-access.ts
+++ b/test/security/operator-reduce-fee-access.ts
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import { initializeContract, owners, DataGenerator, CONFIG } from '../helpers/contract-helpers';
+
+describe('Security: operator reduce fee access control', () => {
+  let ssvNetwork: any;
+
+  beforeEach(async () => {
+    const metadata = await initializeContract();
+    ssvNetwork = metadata.ssvNetwork;
+    await ssvNetwork.write.registerOperator([
+      DataGenerator.publicKey(0),
+      CONFIG.minimalOperatorFee * 2n,
+      true,
+    ], { account: owners[0].account });
+  });
+
+  it('non-owner cannot reduce operator fee', async () => {
+    await expect(
+      ssvNetwork.write.reduceOperatorFee([1n, CONFIG.minimalOperatorFee], { account: owners[1].account })
+    ).to.be.rejectedWith('CallerNotOwnerWithData');
+  });
+
+  it('operator owner can reduce fee', async () => {
+    await expect(
+      ssvNetwork.write.reduceOperatorFee([1n, CONFIG.minimalOperatorFee], { account: owners[0].account })
+    ).to.not.be.rejected;
+  });
+});


### PR DESCRIPTION
## Summary
- add security test ensuring only operator owner can reduce fee
- record vector in TestedVectors documentation

## Testing
- `npm test -- test/security/operator-reduce-fee-access.ts`

------
https://chatgpt.com/codex/tasks/task_e_68adf0affe68832dbc988b04272d4f1b