### PR TITLE
chore: document free operator registration risk

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -200,3 +200,7 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: Medium (access control)
   - *Test File*: `test/security/operator-whitelisting-contract-access.ts`
   - *Result*: Non-owner attempts to remove operator whitelisting contract revert with `CallerNotOwnerWithData`; vector managed.
+**Free operator registration storage bloat**
+ - *Severity*: Medium (resource exhaustion)
+ - *Test File*: `test/security/free-operator-registration.ts`
+ - *Result*: Operators can be registered with zero fee, allowing unlimited state growth without token deposit; vector vulnerable.

--- a/test/security/free-operator-registration.ts
+++ b/test/security/free-operator-registration.ts
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { initializeContract, DataGenerator, owners } from '../helpers/contract-helpers';
+
+// Demonstrates that operators can be registered with zero fee, enabling unbounded storage growth
+// as an attacker can create unlimited operator entries without depositing tokens.
+
+describe('Security: Free operator registration', () => {
+  it('allows registering operators with zero fee', async () => {
+    const { ssvNetwork, ssvNetworkViews } = await initializeContract();
+
+    await ssvNetwork.write.registerOperator([DataGenerator.publicKey(0), 0n, false], {
+      account: owners[1].account,
+    });
+    await ssvNetwork.write.registerOperator([DataGenerator.publicKey(1), 0n, false], {
+      account: owners[1].account,
+    });
+
+    expect(await ssvNetworkViews.read.getOperatorById([2])).to.deep.equal([
+      owners[1].account.address, // owner
+      0n, // fee
+      0, // validatorCount
+      ethers.ZeroAddress, // whitelisted address
+      false, // isPrivate
+      true, // active
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add security test showing operators can be registered with zero fee
- document free operator registration storage bloat in TestedVectors

## Testing
- `npx hardhat test test/security/free-operator-registration.ts`


------
https://chatgpt.com/codex/tasks/task_e_68adf0affe68832dbc988b04272d4f1b