### PR TITLE
test: handle duplicate operator IDs

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -200,3 +200,7 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: Medium (access control)
   - *Test File*: `test/security/operator-whitelisting-contract-access.ts`
   - *Result*: Non-owner attempts to remove operator whitelisting contract revert with `CallerNotOwnerWithData`; vector managed.
+- **Unsorted or Duplicate Operator IDs in Whitelisting Contract Update**
+  - *Severity*: Medium (input validation)
+  - *Test File*: `test/security/whitelisting-contract-duplicates.ts`
+  - *Result*: `setOperatorsWhitelistingContract` accepts unsorted or duplicate operator IDs; function succeeds without state corruption, indicating vector is managed.

--- a/test/security/whitelisting-contract-duplicates.ts
+++ b/test/security/whitelisting-contract-duplicates.ts
@@ -1,0 +1,35 @@
+import hre from 'hardhat';
+import { expect } from 'chai';
+import { initializeContract, registerOperators, owners, CONFIG } from '../helpers/contract-helpers';
+
+describe('Security: whitelisting contract duplicate operator IDs', () => {
+  let ssvNetwork: any;
+  let ssvNetworkViews: any;
+  let mockWhitelistingContract: any;
+
+  beforeEach(async () => {
+    const metadata = await initializeContract();
+    ssvNetwork = metadata.ssvNetwork;
+    ssvNetworkViews = metadata.ssvNetworkViews;
+    mockWhitelistingContract = await hre.viem.deployContract('MockWhitelistingContract', [[]], {
+      client: owners[0].client,
+    });
+    await registerOperators(1, 2, CONFIG.minimalOperatorFee);
+  });
+
+  it('allows unsorted or duplicate operator IDs when setting whitelisting contract', async () => {
+    const contractAddr = await mockWhitelistingContract.address;
+    await expect(
+      ssvNetwork.write.setOperatorsWhitelistingContract([[2, 1, 1], contractAddr], {
+        account: owners[1].account,
+      })
+    ).to.not.be.rejected;
+
+    const operator1 = await ssvNetworkViews.read.getOperatorById([1]);
+    const operator2 = await ssvNetworkViews.read.getOperatorById([2]);
+
+    expect((operator1[3] as string).toLowerCase()).to.equal(contractAddr.toLowerCase());
+    expect((operator2[3] as string).toLowerCase()).to.equal(contractAddr.toLowerCase());
+  });
+});
+


### PR DESCRIPTION
## Summary
- test setting whitelisting contract with duplicate operator IDs
- document vector analysis in `TestedVectors.md`

## Testing
- `npm test test/security/whitelisting-contract-duplicates.ts`


------
https://chatgpt.com/codex/tasks/task_e_68adf0affe68832dbc988b04272d4f1b