### PR TITLE
test: document whitelisting contract removal input edge cases

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -241,3 +241,8 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: Medium (input validation)
   - *Test File*: `test/security/whitelisting-contract-duplicates.ts`
   - *Result*: `setOperatorsWhitelistingContract` accepts unsorted or duplicate operator IDs; function succeeds without state corruption, indicating vector is managed.
+**Unsorted or Duplicate Operator IDs in Whitelisting Contract Removal**
+ - *Severity*: Medium (input validation)
+ - *Test File*: `test/security/remove-whitelisting-contract-duplicates.ts`
+ - *Result*: `removeOperatorsWhitelistingContract` accepts unsorted or duplicate operator IDs; function succeeds without state corruption, indicating vector is managed.
+

--- a/test/security/remove-whitelisting-contract-duplicates.ts
+++ b/test/security/remove-whitelisting-contract-duplicates.ts
@@ -1,0 +1,36 @@
+import hre from 'hardhat';
+import { expect } from 'chai';
+import { initializeContract, registerOperators, owners, CONFIG } from '../helpers/contract-helpers';
+
+describe('Security: whitelisting contract removal duplicate operator IDs', () => {
+  let ssvNetwork: any;
+  let ssvNetworkViews: any;
+  let mockWhitelistingContract: any;
+
+  beforeEach(async () => {
+    const metadata = await initializeContract();
+    ssvNetwork = metadata.ssvNetwork;
+    ssvNetworkViews = metadata.ssvNetworkViews;
+    mockWhitelistingContract = await hre.viem.deployContract('MockWhitelistingContract', [[]], {
+      client: owners[0].client,
+    });
+    await registerOperators(1, 2, CONFIG.minimalOperatorFee);
+    const contractAddr = await mockWhitelistingContract.address;
+    await ssvNetwork.write.setOperatorsWhitelistingContract([[1, 2], contractAddr], {
+      account: owners[1].account,
+    });
+  });
+
+  it('allows unsorted or duplicate operator IDs when removing whitelisting contract', async () => {
+    await expect(
+      ssvNetwork.write.removeOperatorsWhitelistingContract([[2, 1, 1]], {
+        account: owners[1].account,
+      }),
+    ).to.not.be.rejected;
+
+    const operator1 = await ssvNetworkViews.read.getOperatorById([1]);
+    const operator2 = await ssvNetworkViews.read.getOperatorById([2]);
+    expect(operator1[3]).to.equal(hre.ethers.ZeroAddress);
+    expect(operator2[3]).to.equal(hre.ethers.ZeroAddress);
+  });
+});


### PR DESCRIPTION
## Summary
- add security test for `removeOperatorsWhitelistingContract` with unsorted/duplicate operator IDs
- note coverage in `TestedVectors.md`

## Testing
- `npx hardhat test test/security/remove-whitelisting-contract-duplicates.ts`
- `slither contracts/modules/SSVOperatorsWhitelist.sol --solc-remaps '@openzeppelin=node_modules/@openzeppelin'`

------
https://chatgpt.com/codex/tasks/task_e_68af828e8498832da4fb8e053ffc3237