### PR TITLE
docs: record operator fee window enforcement

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -241,3 +241,8 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: Medium (input validation)
   - *Test File*: `test/security/whitelisting-contract-duplicates.ts`
   - *Result*: `setOperatorsWhitelistingContract` accepts unsorted or duplicate operator IDs; function succeeds without state corruption, indicating vector is managed.
+
+**Operator Fee Execution Outside Time Window**
+ - *Severity*: Medium (timing manipulation)
+ - *Test File*: `test/operators/update-fee.ts`
+ - *Result*: `executeOperatorFee` reverts with `ApprovalNotWithinTimeframe` when called before or after the allowed window, showing the vector is managed.


### PR DESCRIPTION
## Summary
- document that executing declared operator fee outside the allowed window reverts with `ApprovalNotWithinTimeframe`

## Testing
- `npm test test/operators/update-fee.ts`

------
https://chatgpt.com/codex/tasks/task_e_68af828e8498832da4fb8e053ffc3237