### PR TITLE
test: verify bulk validator registration operator list

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -241,3 +241,8 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: Medium (input validation)
   - *Test File*: `test/security/whitelisting-contract-duplicates.ts`
   - *Result*: `setOperatorsWhitelistingContract` accepts unsorted or duplicate operator IDs; function succeeds without state corruption, indicating vector is managed.
+- **Unsorted or duplicate operator IDs in bulk validator registration**
+  - *Severity*: Medium (input validation)
+  - *Test File*: `test/security/bulk-register-unsorted.ts`
+  - *Result*: Calls with unsorted or duplicate operator IDs revert with "UnsortedOperatorsList" or "OperatorsListNotUnique"; vector managed.
+

--- a/test/security/bulk-register-unsorted.ts
+++ b/test/security/bulk-register-unsorted.ts
@@ -1,0 +1,78 @@
+import hre from 'hardhat';
+import { expect } from 'chai';
+import {
+  initializeContract,
+  registerOperators,
+  owners,
+  DataGenerator,
+  CONFIG,
+} from '../helpers/contract-helpers';
+
+/**
+ * Validate operator ID ordering and uniqueness for bulk validator registration.
+ */
+describe('Security: bulk register validator operator list validation', () => {
+  let ssvNetwork: any;
+  let ssvToken: any;
+  let minDepositAmount: bigint;
+
+  beforeEach(async () => {
+    const metadata = await initializeContract();
+    ssvNetwork = metadata.ssvNetwork;
+    ssvToken = metadata.ssvToken;
+    await registerOperators(0, 14, CONFIG.minimalOperatorFee);
+    minDepositAmount =
+      (BigInt(CONFIG.minimalBlocksBeforeLiquidation) + 2n) *
+      CONFIG.minimalOperatorFee *
+      13n;
+  });
+
+  it('reverts when operator IDs are unsorted', async () => {
+    await ssvToken.write.approve([ssvNetwork.address, minDepositAmount], {
+      account: owners[1].account,
+    });
+    await expect(
+      ssvNetwork.write.bulkRegisterValidator(
+        [
+          [DataGenerator.publicKey(1)],
+          [3, 2, 1, 4],
+          [await DataGenerator.shares(1, 1, [3, 2, 1, 4])],
+          minDepositAmount,
+          {
+            validatorCount: 0,
+            networkFeeIndex: 0,
+            index: 0,
+            balance: 0n,
+            active: true,
+          },
+        ],
+        { account: owners[1].account },
+      ),
+    ).to.be.rejectedWith('UnsortedOperatorsList');
+  });
+
+  it('reverts when operator IDs contain duplicates', async () => {
+    await ssvToken.write.approve([ssvNetwork.address, minDepositAmount], {
+      account: owners[1].account,
+    });
+    await expect(
+      ssvNetwork.write.bulkRegisterValidator(
+        [
+          [DataGenerator.publicKey(1)],
+          [2, 2, 3, 4],
+          [await DataGenerator.shares(1, 1, [2, 3, 4, 5])],
+          minDepositAmount,
+          {
+            validatorCount: 0,
+            networkFeeIndex: 0,
+            index: 0,
+            balance: 0n,
+            active: true,
+          },
+        ],
+        { account: owners[1].account },
+      ),
+    ).to.be.rejectedWith('OperatorsListNotUnique');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add security tests ensuring bulk validator registration rejects unsorted or duplicate operator IDs
- document vector management in TestedVectors.md

## Testing
- `npx hardhat test test/security/bulk-register-unsorted.ts`


------
https://chatgpt.com/codex/tasks/task_e_68af828e8498832da4fb8e053ffc3237