### PR TITLE
test: demonstrate zero address init DoS for views

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -241,3 +241,7 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: Medium (input validation)
   - *Test File*: `test/security/whitelisting-contract-duplicates.ts`
   - *Result*: `setOperatorsWhitelistingContract` accepts unsorted or duplicate operator IDs; function succeeds without state corruption, indicating vector is managed.
+**Zero Address Initialization of SSVNetworkViews**
+ - *Severity*: Medium (availability)
+ - *Test File*: `test/security/views-zero-address.ts`
+ - *Result*: Initializing `SSVNetworkViews` with `address(0)` succeeds, and subsequent view calls revert, leaving the contract unusable.

--- a/test/security/views-zero-address.ts
+++ b/test/security/views-zero-address.ts
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import { ethers, upgrades } from 'hardhat';
+
+// Test that initializing SSVNetworkViews with address(0) bricks the contract
+// by making subsequent view calls revert.
+describe('SSVNetworkViews: zero address initialization', function () {
+  it('allows initializing with address(0), rendering views unusable', async function () {
+    const [attacker] = await ethers.getSigners();
+    const ViewsFactory = await ethers.getContractFactory('SSVNetworkViews');
+    const proxy = await upgrades.deployProxy(ViewsFactory, [], {
+      kind: 'uups',
+      initializer: false,
+    });
+    await proxy.waitForDeployment();
+    const views = await ethers.getContractAt('SSVNetworkViews', await proxy.getAddress(), attacker);
+
+    await views.initialize(ethers.ZeroAddress);
+
+    await expect(views.getNetworkFee()).to.be.reverted;
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test showing SSVNetworkViews can be initialized with address(0)
- document zero-address initialization DoS vector in TestedVectors.md

## Testing
- `npx hardhat test test/security/views-zero-address.ts`

------
https://chatgpt.com/codex/tasks/task_e_68af828c6eb0832d923098c4a7e5bdc1