### PR TITLE
test: cover non-compliant token withdrawal

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -241,3 +241,8 @@ This document tracks security vectors analyzed in the repository.
   - *Severity*: Medium (input validation)
   - *Test File*: `test/security/whitelisting-contract-duplicates.ts`
   - *Result*: `setOperatorsWhitelistingContract` accepts unsorted or duplicate operator IDs; function succeeds without state corruption, indicating vector is managed.
+
+**Non-Compliant ERC20 Withdrawal**
+- *Severity*: Medium (token handling)
+- *Test File*: `test/security/non-compliant-withdraw.ts`
+- *Result*: `withdrawNetworkEarnings` reverts with 'TokenTransferFailed' when the token's `transfer` returns false, leaving balances unchanged.

--- a/test/security/non-compliant-withdraw.ts
+++ b/test/security/non-compliant-withdraw.ts
@@ -1,0 +1,19 @@
+import { initializeContract } from '../helpers/contract-helpers';
+import { expect } from 'chai';
+
+let ssvNetwork: any;
+let owner: any;
+
+describe('Non-compliant ERC20 withdrawal', () => {
+  beforeEach(async () => {
+    const metadata = await initializeContract('FailingToken');
+    ssvNetwork = metadata.ssvNetwork;
+    owner = metadata.ssvContractsOwner;
+  });
+
+  it('reverts when token transfer returns false during withdrawal', async () => {
+    await expect(
+      ssvNetwork.write.withdrawNetworkEarnings([0n], { account: owner })
+    ).to.be.rejectedWith('TokenTransferFailed');
+  });
+});


### PR DESCRIPTION
## Summary
- test withdrawal from DAO with ERC20 token that fails transfers
- document coverage of non-compliant token withdrawal in TestedVectors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af828c6eb0832d923098c4a7e5bdc1